### PR TITLE
Adds black- and whitelist option for Satis downloads

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,12 +33,14 @@ Role Variables
 - `satis_repo_name`: (string) Repository name
 - `satis_repo_homepage`: (string) Repository URL
 - `satis_repos`: (hashlist)
-- `satis_require`: null (is don't needed) or key/value hash with repositories version
+- `satis_require`: (optional) key/value hash with repositories version
 - `satis_skip_dev`: (bool)
 - `satis_composer_ignore_secure_http`: (bool)
 - `satis_require_all`: (bool)
 - `satis_require_dependencies`: (bool)
 - `satis_require_dev_dependencies`: (bool)
+- `satis_archive_whitelist`: (optional) if set as a list of package names, satis will only dump the dist files of these packages
+- `satis_archive_blacklist`: (optional) if set as a list of package names, satis will not dump the dist files of these packages
 
 Dependencies
 ------------

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -9,6 +9,7 @@ satis_user_home: "/home/satis"
 satis_installation: "{{ satis_user_home }}/satis"
 satis_config_file: "{{ satis_user_home }}/satis.json"
 satis_build_dir: "/opt/satis"
+satis_manage_cron: true
 
 # Configuration
 satis_repo_name: "satis repository"
@@ -22,4 +23,5 @@ satis_composer_ignore_secure_http: false
 satis_require_all: true
 satis_require_dependencies: true
 satis_require_dev_dependencies: false
-satis_manage_cron: true
+satis_archive_whitelist: []
+satis_archive_blacklist: []

--- a/templates/satis.json.j2
+++ b/templates/satis.json.j2
@@ -7,8 +7,14 @@
 	"require-dependencies": {{ satis_require_dependencies | to_json }},
 	"require-dev-dependencies": {{ satis_require_dev_dependencies | to_json }},
 	"archive": {
-		{% if satis_archive_whitelist %}"whitelist": {{ satis_archive_whitelist | to_nice_json(indent=20) }},{% endif %}
-		{% if satis_archive_blacklist %}"blacklist": {{ satis_archive_blacklist | to_nice_json(indent=20) }},{% endif %}
+		"whitelist": [{% for item in satis_archive_whitelist %}
+
+			"{{ item }}"{% if not loop.last %},{% endif %}
+		{%- endfor %} ],
+		"blacklist": [{% for item in satis_archive_blacklist %}
+
+			"{{ item }}"{% if not loop.last %},{% endif %}
+		{%- endfor %} ],
 		"directory": "dist",
 		"format": "zip"
 	}

--- a/templates/satis.json.j2
+++ b/templates/satis.json.j2
@@ -7,9 +7,9 @@
 	"require-dependencies": {{ satis_require_dependencies | to_json }},
 	"require-dev-dependencies": {{ satis_require_dev_dependencies | to_json }},
 	"archive": {
-		"directory": "dist",
-		"format": "zip",
 		{% if satis_archive_whitelist %}"whitelist": {{ satis_archive_whitelist | to_nice_json(indent=20) }},{% endif %}
-		{% if satis_archive_blacklist %}"blacklist": {{ satis_archive_blacklist | to_nice_json(indent=20) }}{% endif %}
+		{% if satis_archive_blacklist %}"blacklist": {{ satis_archive_blacklist | to_nice_json(indent=20) }},{% endif %}
+		"directory": "dist",
+		"format": "zip"
 	}
 }

--- a/templates/satis.json.j2
+++ b/templates/satis.json.j2
@@ -9,7 +9,7 @@
 	"archive": {
 		"directory": "dist",
 		"format": "zip",
-		{%- if satis_archive_whitelist %}"whitelist": {{ satis_archive_whitelist | to_nice_json }},{% endif %}
-		{%- if satis_archive_blacklist %}"blacklist": {{ satis_archive_blacklist | to_nice_json }}{% endif %}
+		{% if satis_archive_whitelist %}"whitelist": {{ satis_archive_whitelist | to_nice_json(indent=20) }},{% endif %}
+		{% if satis_archive_blacklist %}"blacklist": {{ satis_archive_blacklist | to_nice_json(indent=20) }}{% endif %}
 	}
 }

--- a/templates/satis.json.j2
+++ b/templates/satis.json.j2
@@ -2,13 +2,14 @@
 	"name": "{{ satis_repo_name }}",
 	"homepage": "{{ satis_repo_homepage }}",
 	"repositories": {{ satis_repos | to_nice_json }},
-	{%- if satis_require is not none %}"require": {{ satis_require | to_nice_json }},{% endif %}
+	{%- if satis_require %}"require": {{ satis_require | to_nice_json }},{% endif %}
 	"require-all": {{ satis_require_all | to_json }},
 	"require-dependencies": {{ satis_require_dependencies | to_json }},
 	"require-dev-dependencies": {{ satis_require_dev_dependencies | to_json }},
 	"archive": {
 		"directory": "dist",
 		"format": "zip",
-		"skip-dev": {{ satis_skip_dev | to_json }}
+		{%- if satis_archive_whitelist %}"whitelist": {{ satis_archive_whitelist | to_nice_json }},{% endif %}
+		{%- if satis_archive_blacklist %}"blacklist": {{ satis_archive_blacklist | to_nice_json }}{% endif %}
 	}
 }

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -6,6 +6,12 @@
     satis_require:
       'symfony/polyfill-apcu': '*'
     satis_manage_cron: false
+    satis_archive_whitelist:
+      - test/test
+      - test/test1
+    satis_archive_blacklist:
+      - test/test
+      - test/test1
 
   pre_tasks:
     - name: APT | Install tools


### PR DESCRIPTION
Adds a blacklist and whitelist option for Satis download as explained here: [docs](https://getcomposer.org/doc/articles/handling-private-packages-with-satis.md#downloads)
In short it allows packages to be pulled from Bitbucket/Gitlab/Github directly and not to be cached in Satis.
Works fine only 'problem' is the satis.json output, it looks like the following:
```
        "archive": {
                "directory": "dist",
                "format": "zip","whitelist": [
    "test/test"
],"blacklist": [
    "test/test"
]       }
}
```
@HanXHX Do you have a suggestion to overcome this?

Also minor edits in the README.md and moved the cron option in defaults.yml to the same location as in README.md