### PR TITLE
Run build command as satis user

### DIFF
--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -1,10 +1,21 @@
 ---
 
+- name: YUM | Install acl
+  yum:
+    name: acl
+    state: present
+  when: ansible_os_family == "RedHat"
+
+- name: APT | Install acl
+  apt:
+    name: acl
+    state: present
+  when: ansible_os_family == "Debian"
+
 - name: STAT | Check if satis is installed
   stat:
     path: "{{ satis_installation }}"
   register: satis_installed
-
 
 - name: COMPOSER | Install satis
   composer:

--- a/tasks/satis.yml
+++ b/tasks/satis.yml
@@ -24,6 +24,8 @@
   when: >
     satis_config_file_created.changed == true or
     find_satis_build_dir.matched == 0
+  become: yes
+  become_user: "{{ satis_user }}"
 
 - name: FILE | Fix owner/group
   file:


### PR DESCRIPTION
As the title states, run the satis build command as the satis user. This resolves the issue when using private repositories with ssh-key access only granted to the satis user.
The acl package install is needed for security, otherwise Ansible complains:
`Failed to set permissions on the temporary files Ansible needs to create when becoming an unprivileged user. For information on working around this, see https://docs.ansible.com/ansible/become.html#becoming-an-unprivileged-user`

I tested it on a CentOS 7 host and it worked without a problem.