### PR TITLE
Makes archives optional, adds config, providers and notify_batch

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,14 +17,14 @@ Role Variables
 
 ### System
 
-- `satis_user`
-- `satis_group`
-- `satis_user_home`
+- `satis_user`: Username which satis is installed as, is created when non existing
+- `satis_group` Usergroup which satis is installed as, is created when non existing
+- `satis_user_home` Location of the userhome of the satis user
 
 ### Install
 
 - `satis_installation`: Install directory
-- `satis_config_file`: Satis configuration file
+- `satis_config_file`: Satis configuration file location
 - `satis_build_dir`: Build directory
 - `satis_manage_cron`: (bool) manage crontab 
 - `satis_version`: Satis version to install (alpha for latest pre-release, dev for master branch)
@@ -34,14 +34,16 @@ Role Variables
 - `satis_repo_name`: (string) Repository name
 - `satis_repo_homepage`: (string) Repository URL
 - `satis_repos`: (hashlist)
-- `satis_require`: (optional) key/value hash with repositories version
+- `satis_require`: (optional) Key/value hash with repositories version
 - `satis_skip_dev`: (bool)
-- `satis_composer_ignore_secure_http`: (bool)
+- `satis_composer_ignore_secure_http`: (bool) Composer secure-http setting ([docs](https://getcomposer.org/doc/06-config.md#secure-http))
 - `satis_require_all`: (bool)
 - `satis_require_dependencies`: (bool)
 - `satis_require_dev_dependencies`: (bool)
-- `satis_archive_whitelist`: (optional) if set as a list of package names, satis will only dump the dist files of these packages
-- `satis_archive_blacklist`: (optional) if set as a list of package names, satis will not dump the dist files of these packages
+- `satis_archive`: (optional) Can be used to set all the Satis archive options [docs](https://getcomposer.org/doc/articles/handling-private-packages-with-satis.md#downloads) Define like the JSON but in YAML so no braces etc [example](defaults/main.yml)
+- `satis_providers`: (optional) When set to true each package will be dumped into a separate include file which will be only loaded by composer when the package is really required. [docs](https://getcomposer.org/doc/articles/handling-private-packages-with-satis.md#other-options)
+- `satis_config`: (optional) Can be used to set composer options [docs](https://getcomposer.org/doc/articles/handling-private-packages-with-satis.md#downloads)
+- `satis_notify_batch`: (optional) specify a callback URL [docs](https://getcomposer.org/doc/articles/handling-private-packages-with-satis.md#downloads)
 
 Dependencies
 ------------

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -16,13 +16,19 @@ satis_version: "alpha"
 satis_repo_name: "satis repository"
 satis_repo_homepage: "http://localhost/"
 satis_repos:
-- type: "composer"
-  url: "https://packagist.org"
+  - type: "composer"
+    url: "https://packagist.org"
 satis_require: {}
 satis_skip_dev: false
 satis_composer_ignore_secure_http: false
 satis_require_all: true
 satis_require_dependencies: true
 satis_require_dev_dependencies: false
-satis_archive_whitelist: []
-satis_archive_blacklist: []
+satis_archive:
+  whitelist: []
+  blacklist: []
+  directory: dist
+  format: zip
+satis_providers: false
+satis_config: {}
+satis_notify_batch: ""

--- a/templates/satis.json.j2
+++ b/templates/satis.json.j2
@@ -1,21 +1,14 @@
 {
-	"name": "{{ satis_repo_name }}",
-	"homepage": "{{ satis_repo_homepage }}",
-	"repositories": {{ satis_repos | to_nice_json }},
-	{%- if satis_require %}"require": {{ satis_require | to_nice_json }},{% endif %}
-	"require-all": {{ satis_require_all | to_json }},
-	"require-dependencies": {{ satis_require_dependencies | to_json }},
-	"require-dev-dependencies": {{ satis_require_dev_dependencies | to_json }},
-	"archive": {
-		"whitelist": [{% for item in satis_archive_whitelist %}
+  "name": "{{ satis_repo_name }}",
+  "homepage": "{{ satis_repo_homepage }}",
+  "repositories": {{ satis_repos | to_nice_json }},
+{% if satis_archive %}  "archive": {{ satis_archive | to_nice_json }},{% endif %}
+{% if satis_providers %}  "providers": {{ satis_providers | to_json }},{% endif %}
+{% if satis_config %}  "config": {{ satis_config | to_nice_json }},{% endif %}
+{% if satis_notify_batch %}  "notify-batch": {{ satis_notify_batch | to_json }},{% endif %}
+{% if satis_require %}  "require": {{ satis_require | to_nice_json }},{% endif %}
 
-			"{{ item }}"{% if not loop.last %},{% endif %}
-		{%- endfor %} ],
-		"blacklist": [{% for item in satis_archive_blacklist %}
-
-			"{{ item }}"{% if not loop.last %},{% endif %}
-		{%- endfor %} ],
-		"directory": "dist",
-		"format": "zip"
-	}
+  "require-all": {{ satis_require_all | to_json }},
+  "require-dependencies": {{ satis_require_dependencies | to_json }},
+  "require-dev-dependencies": {{ satis_require_dev_dependencies | to_json }}
 }

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -6,12 +6,20 @@
     satis_require:
       'symfony/polyfill-apcu': '*'
     satis_manage_cron: false
-    satis_archive_whitelist:
-      - test/test
-      - test/test1
-    satis_archive_blacklist:
-      - test/test
-      - test/test1
+    satis_archive:
+      whitelist:
+        - test/test
+        - test/test1
+      blacklist:
+        - test/test
+        - test/test1
+      directory: dist
+      format: zip
+    satis_providers: true
+    satis_config:
+      gitlab-domains:
+        - gitlab.com
+    satis_notify_batch: /downloads/
 
   pre_tasks:
     - name: APT | Install tools


### PR DESCRIPTION
Satis can act as a gateway to Gitlab/Github and serve the tarballs directly from there ([PR at composer](https://github.com/composer/composer/pull/3765#issuecomment-245612489), [some docs](https://getcomposer.org/doc/05-repositories.md#using-private-repositories)) in that case the `archive_option` is not needed and now made optional. Also I made the `archive_option` more flexible to use since it is now a hashlist(?)e, so all the options possible in Satis can be defined easily (and the j2 template and output look nicer).
For that same gateway case the `satis_config` variable is added to be able to define the gitlab-domains but satis_config can be used to define all kinds of composer variables ([docs](https://getcomposer.org/doc/articles/handling-private-packages-with-satis.md#other-options)).
For this gateway style Satis I use the following config:
```yaml
satis_archive: {}
satis_config:
  gitlab-domains:
    - gitlab.com
```
Since I was at it I also added the `satis_providers` and `satis_notify_batch` variables ([docs](https://getcomposer.org/doc/articles/handling-private-packages-with-satis.md#downloads)).

This archive_option to nice_json output looked so nice that I started with a satis_json variable to cover all the options and made the template way simpler (`"{{ satis_json | to_nice_json }}"`. 
This would make the role way more easy to maintain since each option added to satis.json can be defined without changing anything in the role.
It was after the (untested) completion that I realized the one big caveat of this approach, the variable needs to be defined with all the needed options in the host_vars/group_vars. There is no way (that I know of) to override values in a hashlist. You can find the attempt [here](https://github.com/wilmardo/ansible-satis/commit/72e47499004daa3900ee86aed3497568e366b6a0). 

Let me know what you think about both ideas 👍 