### PR TITLE
Tag build command

### DIFF
--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="$PROJECT_DIR$" vcs="Git" />
+  </component>
+</project>

--- a/README.md
+++ b/README.md
@@ -45,6 +45,11 @@ Role Variables
 - `satis_config`: (optional) Can be used to set composer options [docs](https://getcomposer.org/doc/articles/handling-private-packages-with-satis.md#downloads)
 - `satis_notify_batch`: (optional) specify a callback URL [docs](https://getcomposer.org/doc/articles/handling-private-packages-with-satis.md#downloads)
 
+### Tags available
+Can be used like this `ansible-playbook example.yml --tags "build"` for more information see [Ansible docs](https://docs.ansible.com/ansible/latest/playbooks_tags.html)
+
+- `build`: Runs the satis build command even when no configuration has changed.
+
 Dependencies
 ------------
 

--- a/tasks/satis.yml
+++ b/tasks/satis.yml
@@ -5,6 +5,7 @@
     src: "satis.json.j2"
     dest: "{{ satis_config_file }}"
   register: satis_config_file_created
+  tags: build
 
 - name: FILE | Create build dir
   file:
@@ -18,14 +19,20 @@
   find:
     paths: "{{ satis_build_dir }}"
   register: find_satis_build_dir
+  tags: build
+
+- set_fact:
+    no_build_tag: yes
 
 - name: COMMAND | Build the repository
   command: "{{ satis_build_command }}"
   when: >
     satis_config_file_created.changed == true or
-    find_satis_build_dir.matched == 0
+    find_satis_build_dir.matched == 0 or
+    no_build_tag is undefined
   become: yes
   become_user: "{{ satis_user }}"
+  tags: build
 
 - name: FILE | Fix owner/group
   file:


### PR DESCRIPTION
Adds build tag to the role, this allows to force rebuild the role if needed. For example if a new release is drafted this playbook is triggered with the build tag by some automation tool. So the new version is almost directly available in Satis.

There is no way in Ansible to check if a tag is used, therefore each 'normal' run defines the variable `no_build_tag`. When run with the build tag, the set_fact is untagged and skipped so the `no_build_tag` is undefined. If the `no_build_tag` is undefined means that this is a tagged run and the build command is triggered.

If you see a better way to check for tags, let me know :)

PS. Thanks for the fast merging last time 👍 
